### PR TITLE
Functional composition

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -257,32 +257,31 @@ class FunctionCall extends Expression {
   }
 
   evaluate(argContext?: FunctionArgContext): string | number | boolean {
-    const functionArguments = this.args as (Primitive | List)[];
-    return FunctionCall.apply(this._function, functionArguments, argContext);
+    return FunctionCall.apply(this._function, this.args, argContext);
   }
 
-  static flatten(args: (Primitive | List)[]): (string | number | boolean)[] {
+  static flatten(
+    args: LiteralOrList[],
+    argContext?: FunctionArgContext
+  ): (string | number | boolean)[] {
     return args.reduce((acc, curr) => {
-      if (curr instanceof Primitive || curr instanceof Expression) {
-        return [...acc, curr.evaluate()];
+      if (curr instanceof Literal || curr instanceof Expression) {
+        return [...acc, curr.evaluate(argContext)];
       } else {
-        return [
-          ...acc,
-          ...FunctionCall.flatten(curr.args as (Primitive | List)[]),
-        ];
+        return [...acc, ...FunctionCall.flatten(curr.args)];
       }
     }, []);
   }
 
   static apply(
     func: LanguageFunction,
-    args: (Primitive | List)[],
+    args: LiteralOrList[],
     prevArgContext?: FunctionArgContext
   ): string | number | boolean {
-    const argValues = FunctionCall.flatten(args);
+    const argValues = FunctionCall.flatten(args, prevArgContext);
     const argContext: Record<string, string | number | boolean> = {};
     func.arguments.args.forEach((arg, i) => {
-      const value = arg.evaluate(prevArgContext) as string;
+      const value = arg.evaluate() as string;
       argContext[value] = argValues[i];
     });
 

--- a/test.arp
+++ b/test.arp
@@ -1,13 +1,6 @@
 (
     (defunc add (a b) (+ a b)) 
-    (add 1 (add 2 3))
     (defunc square (a) (* a a))
-    (square 3)
-    (add 2 (square 4))
-    (defunc concat (a b) (+ a " " b))
-    (concat "a" "b")
-
-    (defunc even_or_odd (num) (if (re num 2) "odd" "even"))
-    (even_or_odd 4)
-    (even_or_odd 7)
+    (defunc add_and_square (a b) (square (add a b)))
+    (add_and_square 2 3)
 )


### PR DESCRIPTION
Add support for functional composition.

```lisp
(
    (defunc add (a b) (+ a b)) 
    (defunc square (a) (* a a))
    (defunc add_and_square (a b) (square (add a b)))
    (add_and_square 2 3)
)
```